### PR TITLE
Changed sources URL in contact

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -10,7 +10,7 @@
   ],
   "contact": {
     "homepage": "https://glass-launcher.net/",
-    "sources": "https://github.com/calmilamsy/BIN-fabric-example-mod"
+    "sources": "https://github.com/calmilamsy/stationapi-example-mod"
   },
 
   "license": "CC0-1.0",


### PR DESCRIPTION
it was pointing to `BIN-fabric-example-mod` repo instead of `stationapi-example-mod`