### PR TITLE
Update examplemod.mixins.json

### DIFF
--- a/src/main/resources/examplemod.mixins.json
+++ b/src/main/resources/examplemod.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.glasslauncher.example.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ExampleMixin"
   ],


### PR DESCRIPTION
Why do we need JAVA_8 compat level if STAPI cant run on J8?